### PR TITLE
Set test case and tool installation check on prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,5 @@
 include make/*.mk
 
-ARCH := $(shell uname -m)
-LOCAL_ARCH := "amd64"
-ifeq ($(ARCH),x86_64)
-    LOCAL_ARCH="amd64"
-else ifeq ($(ARCH),ppc64le)
-    LOCAL_ARCH="ppc64le"
-else ifeq ($(ARCH),s390x)
-    LOCAL_ARCH="s390x"
-else ifeq ($(ARCH),arm64)
-    LOCAL_ARCH="arm64"
-else
-    $(error "This system's ARCH $(ARCH) isn't recognized/supported")
-endif
-
-OS := $(shell uname)
-ifeq ($(OS),Linux)
-    LOCAL_OS ?= linux
-else ifeq ($(OS),Darwin)
-    LOCAL_OS ?= darwin
-else
-    $(error "This system's OS $(OS) isn't recognized/supported")
-endif
-
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,27 @@
-include make/ibm.mk
+include make/*.mk
+
+ARCH := $(shell uname -m)
+LOCAL_ARCH := "amd64"
+ifeq ($(ARCH),x86_64)
+    LOCAL_ARCH="amd64"
+else ifeq ($(ARCH),ppc64le)
+    LOCAL_ARCH="ppc64le"
+else ifeq ($(ARCH),s390x)
+    LOCAL_ARCH="s390x"
+else ifeq ($(ARCH),arm64)
+    LOCAL_ARCH="arm64"
+else
+    $(error "This system's ARCH $(ARCH) isn't recognized/supported")
+endif
+
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+    LOCAL_OS ?= linux
+else ifeq ($(OS),Darwin)
+    LOCAL_OS ?= darwin
+else
+    $(error "This system's OS $(OS) isn't recognized/supported")
+endif
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.2.1
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/IBM/ibm-account-iam-operator
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.3
 
 require (
 	github.com/WASdev/websphere-liberty-operator v0.0.0-20240605161949-4e0318b69988

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,22 +1,45 @@
-DOCKER_BUILDX ?= buildx
-DOCKER_BUILDX_VERSION ?= v0.12.1
-DOCKER_CLI_PLUGINS ?= ~/.docker/cli-plugins
+# Dependency binaries
+DOCKER_BUILDX ?= $(LOCALBIN)/buildx
+YQ ?= $(LOCALBIN)/yq
 
+# Dependency versions
+DOCKER_BUILDX_VERSION ?= v0.12.1
 YQ_VERSION ?= v4.44.1
 
+# Dependency check and install scripts, for ease of use
+LOCAL_SCRIPTS_MAKEFILE_CHECK_DIR ?= $(LOCAL_SCRIPTS_DIR)/makefile-check
+LOCAL_SCRIPTS_MAKEFILE_INSTALL_DIR ?= $(LOCAL_SCRIPTS_DIR)/makefile-install
+
+
+## Docker Buildx
+
+DOCKER_CLI_PLUGINS ?= ~/.docker/cli-plugins
+# Dir must exist for plugin installation (dir will not be created if buildx command already works and passes the check)
+.PHONY: require-cli-plugins-dir
+require-cli-plugins-dir:
+	mkdir -p $(DOCKER_CLI_PLUGINS)
+
+.PHONY: require-docker-buildx
+require-docker-buildx:
+	@ $(MAKE) check-docker-buildx || $(MAKE) install-docker-buildx
+
+.PHONY: check-docker-buildx
+check-docker-buildx:
+	@ echo "Checking dependency: docker buildx"
+	@ $(LOCAL_SCRIPTS_MAKEFILE_CHECK_DIR)/check-docker-buildx.sh $(DOCKER_BUILDX) $(DOCKER_BUILDX_VERSION) $(DOCKER_CLI_PLUGINS)
+	@ echo "Dependency satisfied: docker buildx"
+
 .PHONY: install-docker-buildx
-install-docker-buildx:
-	@echo "List folder of DOCKER_CLI_PLUGINS: $(DOCKER_CLI_PLUGINS)"
-	ls -la $(DOCKER_CLI_PLUGINS)
-	curl -s -L -f "https://github.com/docker/buildx/releases/download/$(DOCKER_BUILDX_VERSION)/buildx-$(DOCKER_BUILDX_VERSION).$(LOCAL_OS)-$(LOCAL_ARCH)" > "$(LOCALBIN)/$(DOCKER_BUILDX)"
-	chmod a+x "$(DOCKER_BUILDX)"
-	ln -s "$(LOCALBIN)/$(DOCKER_BUILDX)" "$(DOCKER_CLI_PLUGINS)/docker-buildx"
+install-docker-buildx: require-cli-plugins-dir
+	@ echo "Installing dependency: docker buildx"
+	@ $(LOCAL_SCRIPTS_MAKEFILE_INSTALL_DIR)/install-docker-buildx.sh $(DOCKER_BUILDX) $(DOCKER_BUILDX_VERSION) $(DOCKER_CLI_PLUGINS) $(LOCAL_OS) $(LOCAL_ARCH)
+	@ echo "Dependency installed: docker buildx"
+	@ echo "Checking installation successful: docker buildx"
+	@ $(MAKE) check-docker-buildx
 
 
-
-# yq is a lightweight and portable command-line YAML processor
+## YQ is a lightweight and portable command-line YAML processor
 .PHONY: yq
-YQ ?= $(LOCALBIN)/yq
 yq:
 ifeq (,$(wildcard $(YQ)))
 	ifeq (, $(shell which yq 2>/dev/null))

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,6 +1,6 @@
 # Dependency binaries
-DOCKER_BUILDX ?= $(LOCALBIN)/buildx
-YQ ?= $(LOCALBIN)/yq
+DOCKER_BUILDX ?= $(LOCAL_BIN_DIR)/buildx
+YQ ?= $(LOCAL_BIN_DIR)/yq
 
 # Dependency versions
 DOCKER_BUILDX_VERSION ?= v0.12.1
@@ -24,17 +24,17 @@ require-docker-buildx:
 	@ $(MAKE) check-docker-buildx || $(MAKE) install-docker-buildx
 
 .PHONY: check-docker-buildx
-check-docker-buildx:
+check-docker-buildx: require-local-bin-dir
 	@ echo "Checking dependency: docker buildx"
 	@ $(LOCAL_SCRIPTS_MAKEFILE_CHECK_DIR)/check-docker-buildx.sh $(DOCKER_BUILDX) $(DOCKER_BUILDX_VERSION) $(DOCKER_CLI_PLUGINS)
 	@ echo "Dependency satisfied: docker buildx"
 
 .PHONY: install-docker-buildx
-install-docker-buildx: require-cli-plugins-dir
+install-docker-buildx: require-local-bin-dir require-cli-plugins-dir
 	@ echo "Installing dependency: docker buildx"
 	@ $(LOCAL_SCRIPTS_MAKEFILE_INSTALL_DIR)/install-docker-buildx.sh $(DOCKER_BUILDX) $(DOCKER_BUILDX_VERSION) $(DOCKER_CLI_PLUGINS) $(LOCAL_OS) $(LOCAL_ARCH)
 	@ echo "Dependency installed: docker buildx"
-	@ echo "Checking installation successful: docker buildx"
+	@ echo "Checking if installation successful: docker buildx"
 	@ $(MAKE) check-docker-buildx
 
 

--- a/make/deps.mk
+++ b/make/deps.mk
@@ -1,0 +1,32 @@
+DOCKER_BUILDX ?= buildx
+DOCKER_BUILDX_VERSION ?= v0.12.1
+DOCKER_CLI_PLUGINS ?= ~/.docker/cli-plugins
+
+YQ_VERSION ?= v4.44.1
+
+.PHONY: install-docker-buildx
+install-docker-buildx:
+	@echo "List folder of DOCKER_CLI_PLUGINS: $(DOCKER_CLI_PLUGINS)"
+	ls -la $(DOCKER_CLI_PLUGINS)
+	curl -s -L -f "https://github.com/docker/buildx/releases/download/$(DOCKER_BUILDX_VERSION)/buildx-$(DOCKER_BUILDX_VERSION).$(LOCAL_OS)-$(LOCAL_ARCH)" > "$(LOCALBIN)/$(DOCKER_BUILDX)"
+	chmod a+x "$(DOCKER_BUILDX)"
+	ln -s "$(LOCALBIN)/$(DOCKER_BUILDX)" "$(DOCKER_CLI_PLUGINS)/docker-buildx"
+
+
+
+# yq is a lightweight and portable command-line YAML processor
+.PHONY: yq
+YQ ?= $(LOCALBIN)/yq
+yq:
+ifeq (,$(wildcard $(YQ)))
+	ifeq (, $(shell which yq 2>/dev/null))
+		@{ \
+		set -e ;\
+		mkdir -p $(dir $(YQ)) ;\
+		curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(LOCAL_OS)_$(LOCAL_ARCH) ;\
+		chmod +x $(YQ) ;\
+		}
+	else
+		YQ = $(shell which yq)
+	endif
+endif

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -85,4 +85,4 @@ clean-before-commit:
 check: ## @code Run the code check
 	@echo "Running check for the code."
 	@echo "Run make install-docker-buildx"
-	$(MAKE) check-docker-buildx
+	$(MAKE) require-docker-buildx

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -1,7 +1,6 @@
 DEV_VERSION ?= dev # Could be other string or version number
 DEV_REGISTRY ?= quay.io/bedrockinstallerfid
 
-YQ_VERSION ?= v4.44.1
 
 ifneq ($(shell echo "$(DEV_VERSION)" | grep -E '^[^0-9]'),)
 	TAG := $(DEV_VERSION)
@@ -51,25 +50,10 @@ clean-before-commit:
 	sed -e 's/Always/IfNotPresent/g' ./config/manager/tmp.yaml > ./config/manager/manager.yaml
 	rm ./config/manager/tmp.yaml
 
-# yq is a lightweight and portable command-line YAML processor
-.PHONY: yq
-YQ ?= $(LOCALBIN)/yq
-yq:
-ifeq (,$(wildcard $(YQ)))
-ifeq (, $(shell which yq 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(YQ)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$${OS}_$${ARCH} ;\
-	chmod +x $(YQ) ;\
-	}
-else
-YQ = $(shell which yq)
-endif
-endif
 
 # Test
 .PHONY: check
 check: ## @code Run the code check
 	@echo "Running check for the code."
+	@echo "Run make install-docker-buildx"
+	$(MAKE) install-docker-buildx

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -1,8 +1,17 @@
-ROOT_DIR ?= $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+## General
 
-# Local scripts folder used e.g. to store dependencies' installation scripts
+ROOT_DIR ?= $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+# Local bin folder used 
+LOCAL_BIN_DIR ?= $(ROOT_DIR)/bin
+# Local scripts folder used
 LOCAL_SCRIPTS_DIR ?= $(ROOT_DIR)/scripts
 
+
+# Must be created if doesn't exist, as some targets place dependencies into it
+.PHONY: require-local-bin-dir
+require-local-bin-dir:
+	mkdir -p $(LOCAL_BIN_DIR)
+	
 
 ARCH := $(shell uname -m)
 LOCAL_ARCH := "amd64"
@@ -84,5 +93,5 @@ clean-before-commit:
 .PHONY: check
 check: ## @code Run the code check
 	@echo "Running check for the code."
-	@echo "Run make install-docker-buildx"
+	@echo "Runing require docker buildx as pre-check"
 	$(MAKE) require-docker-buildx

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -1,3 +1,32 @@
+ROOT_DIR ?= $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+
+# Local scripts folder used e.g. to store dependencies' installation scripts
+LOCAL_SCRIPTS_DIR ?= $(ROOT_DIR)/scripts
+
+
+ARCH := $(shell uname -m)
+LOCAL_ARCH := "amd64"
+ifeq ($(ARCH),x86_64)
+    LOCAL_ARCH="amd64"
+else ifeq ($(ARCH),ppc64le)
+    LOCAL_ARCH="ppc64le"
+else ifeq ($(ARCH),s390x)
+    LOCAL_ARCH="s390x"
+else ifeq ($(ARCH),arm64)
+    LOCAL_ARCH="arm64"
+else
+    $(error "This system's ARCH $(ARCH) isn't recognized/supported")
+endif
+
+OS := $(shell uname)
+ifeq ($(OS),Linux)
+    LOCAL_OS ?= linux
+else ifeq ($(OS),Darwin)
+    LOCAL_OS ?= darwin
+else
+    $(error "This system's OS $(OS) isn't recognized/supported")
+endif
+
 DEV_VERSION ?= dev # Could be other string or version number
 DEV_REGISTRY ?= quay.io/bedrockinstallerfid
 
@@ -56,4 +85,4 @@ clean-before-commit:
 check: ## @code Run the code check
 	@echo "Running check for the code."
 	@echo "Run make install-docker-buildx"
-	$(MAKE) install-docker-buildx
+	$(MAKE) check-docker-buildx

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -71,3 +71,7 @@ YQ = $(shell which yq)
 endif
 endif
 
+# Test
+.PHONY: test
+test: ## Run unit test on prow
+	@echo "Running unit tests for the controllers."

--- a/make/ibm.mk
+++ b/make/ibm.mk
@@ -29,8 +29,6 @@ configure-dev:
 ##@ Development Build
 .PHONY: docker-build-dev
 docker-build-dev: configure-dev docker-build 
-	@echo "DEV_VERSION: $(DEV_VERSION)"
-	@echo "VERSION: $(VERSION)"
 
 .PHONY: docker-build-push-dev
 docker-build-push-dev: docker-build-dev docker-push
@@ -72,6 +70,6 @@ endif
 endif
 
 # Test
-.PHONY: test
-test: ## Run unit test on prow
-	@echo "Running unit tests for the controllers."
+.PHONY: check
+check: ## @code Run the code check
+	@echo "Running check for the code."

--- a/scripts/makefile-check/check-docker-buildx.sh
+++ b/scripts/makefile-check/check-docker-buildx.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_BUILDX=$1
+DOCKER_BUILDX_VERSION=$2
+DOCKER_CLI_PLUGINS=$3
+
+set -e
+
+# Check if docker buildx works (in case e.g. provided with docker already), if so, always exit with an optional warning
+if docker buildx version &> /dev/null; then
+    version=$(docker buildx version | awk '{print $2}')
+    if [ "$version" = "$DOCKER_BUILDX_VERSION" ]; then
+        exit 0
+    else
+        echo "WARNING! Version mismatch: expected $DOCKER_BUILDX_VERSION, got $version"
+        exit 0
+    fi
+fi
+
+# docker buildx command didn't work, so check plugin exists and is linked to the CLI directory
+test -s "$DOCKER_BUILDX"
+test -s "$DOCKER_CLI_PLUGINS"/docker-buildx

--- a/scripts/makefile-install/install-docker-buildx.sh
+++ b/scripts/makefile-install/install-docker-buildx.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_BUILDX=$1
+DOCKER_BUILDX_VERSION=$2
+DOCKER_CLI_PLUGINS=$3
+LOCAL_OS=$4
+LOCAL_ARCH=$5
+
+set -ex
+
+# Download the binary file
+curl -s -L -f "https://github.com/docker/buildx/releases/download/$DOCKER_BUILDX_VERSION/buildx-$DOCKER_BUILDX_VERSION.$LOCAL_OS-$LOCAL_ARCH" > "$DOCKER_BUILDX"
+chmod a+x "$DOCKER_BUILDX"
+
+# Make a symlink to the local file
+ln -sf "$DOCKER_BUILDX" "$DOCKER_CLI_PLUGINS"/docker-buildx


### PR DESCRIPTION
- Install `docker buildx` tool and check on prow that could be used to build different arch image later.
   <img width="842" alt="Screenshot 2024-07-10 at 17 52 55" src="https://github.com/IBM/ibm-account-iam-operator/assets/59578388/4aab063a-71c8-4c66-b49d-b932b708fd5f">

- Enable simply test case on CICD pipeline  
   - https://github.com/IBM/test-infra/commit/5c6869d0e2ca5bf385ee6c74e32c8fd86cb907f5
   - https://github.com/IBM/test-infra/pull/576