### PR TITLE
config MCSP and update bootstrap secret

### DIFF
--- a/internal/controller/accountiam_controller.go
+++ b/internal/controller/accountiam_controller.go
@@ -59,6 +59,9 @@ type BootstrapSecret struct {
 	DefaultAUDValue     string
 	DefaultIDPValue     string
 	DefaultRealmValue   string
+	GlobalRealmValue    string
+	GlobalAccountIDP    string
+	GlobalAccountAud    string
 }
 
 var BootstrapData BootstrapSecret

--- a/internal/resources/yamls/app.go
+++ b/internal/resources/yamls/app.go
@@ -42,7 +42,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: account-iam-okd-auth
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -60,7 +59,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: account-iam-database-secret
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -76,9 +74,10 @@ stringData:
   pg_db_user: user_accountiam
   pg_jdbc_password_jndi: "jdbc/iamdatasource"
   pgPassword: {{ .PGPassword }}
-  GLOBAL_ACCOUNT_AUD: <>
-  GLOBAL_ACCOUNT_IDP: <>
-  GLOBAL_ACCOUNT_REALM: <>
+data:
+  GLOBAL_ACCOUNT_AUD: {{ .GlobalAccountAud }}
+  GLOBAL_ACCOUNT_IDP: {{ .GlobalAccountIDP }}
+  GLOBAL_ACCOUNT_REALM: {{ .GlobalRealmValue }}
 type: Opaque
 `
 
@@ -87,7 +86,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: account-iam-mpconfig-secrets
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -182,7 +180,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: account-iam-env-configmap-dev
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -200,7 +197,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: account-iam
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -218,7 +214,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: account-iam-db-migration-mcspid
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -258,7 +253,6 @@ spec:
             limits:
               cpu: 500m
               memory: 600Mi
-      restartPolicy: Never
       serviceAccountName: account-iam-migration
       volumes:
         - name: account-iam-token
@@ -276,7 +270,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: account-iam-migration
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all
@@ -289,7 +282,6 @@ apiVersion: liberty.websphere.ibm.com/v1
 kind: WebSphereLibertyApplication
 metadata:
   name: account-iam
-  namespace: mcsp
   labels:
     by-squad: mcsp-user-management
     for-product: all

--- a/internal/resources/yamls/db_bootstrap.go
+++ b/internal/resources/yamls/db_bootstrap.go
@@ -15,8 +15,6 @@ spec:
         image: docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom/mcsp-utils:latest
         command: ["/bin/bash", "/db-init/create_db.sh"]
         volumeMounts:
-        - name: script-volume
-          mountPath: /scripts
         - name: psql-credentials
           mountPath: /psql-credentials
         - name: db-password
@@ -25,9 +23,6 @@ spec:
           mountPath: /data
       restartPolicy: OnFailure
       volumes:
-      - name: script-volume
-        configMap:
-          name: create-account-iam-db
       - name: psql-credentials
         secret:
           secretName: common-service-db-superuser

--- a/internal/resources/yamls/iam_cert_rotation.go
+++ b/internal/resources/yamls/iam_cert_rotation.go
@@ -75,7 +75,10 @@ spec:
             failureThreshold: 3
           env:
             - name: WATCH_NAMESPACE
-              value: mcsp
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
- Inject `Global-*` values, which are used for DB initialization, into the `database` secret.
- Remove the `create-account-iam-db` configmap from the database creation job.
- Remove the watch namespace `mcsp` hard code from the `cert-rotation` deployment and use operator namespace instead.